### PR TITLE
fix(db): add optional SSL support to db/pg.js for cloud Postgres providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,10 @@ PG_DATABASE=yabby
 PG_USER=postgres
 PG_PASSWORD=
 
+# Postgres SSL — set to "true" for cloud providers (Neon, Supabase, AWS RDS).
+# Leave unset or "false" for local Postgres without SSL.
+PG_SSL=
+
 
 # ---------- Redis ----------
 # Live status cache + pub/sub channel. `./setup.sh` will start one if needed.

--- a/db/pg.js
+++ b/db/pg.js
@@ -12,6 +12,7 @@ const pool = new Pool({
   database: process.env.PG_DATABASE || "yabby",
   user:     process.env.PG_USER || "yabby",
   password: process.env.PG_PASSWORD || "",
+  ssl:      process.env.PG_SSL === "true" ? { rejectUnauthorized: true } : false,
   max:      10,
   idleTimeoutMillis: 30000,
   connectionTimeoutMillis: 5000,


### PR DESCRIPTION
Closes #12

## What

Adds an opt-in SSL option to `db/pg.js`'s Pool configuration, controlled via a new `PG_SSL` env variable. Also documents `PG_SSL` in `.env.example` next to the other `PG_*` vars.

## Why

Cloud Postgres providers (Neon, Supabase, AWS RDS) require SSL by default. Without this option, the pool throws `ECONNREFUSED` at startup with no clear signal pointing back to the missing SSL config — see #12 for the full report.

## How

```javascript
ssl: process.env.PG_SSL === "true" ? { rejectUnauthorized: true } : false,
```

- **Backward-compatible:** defaults to `false` — local Postgres setups are unaffected.
- **Opt-in:** activates only when `PG_SSL=true` is set in `.env`.
- **Cert validation enabled:** `rejectUnauthorized: true` per @Idov's suggestion in #12, so we don't silently accept MITM'd connections. Major cloud providers ship certs signed by standard CAs.

## Testing

Tested locally against Neon (Singapore region):
- With `PG_SSL=true` → connects cleanly to Neon over SSL
- Without `PG_SSL` (default) → behaves identically to before, local Postgres unaffected

## Notes

`.env.example` change includes a short comment explaining when to flip the flag.