### PR TITLE
fix: orphaned claude processes — bg-task bookkeeping race + missing SIGKILL escalation

### DIFF
--- a/lib/bg-write-tracker.js
+++ b/lib/bg-write-tracker.js
@@ -1,0 +1,33 @@
+// Tracks in-flight DB writes triggered by Claude CLI bg_task_started /
+// bg_task_notification events so the spawner's close handler can wait for
+// them to settle before declaring tasks orphaned and deleting the process
+// handle. Without this, a child can exit before createBgTask() resolves,
+// leaving an OS process running but no DB row for markOrphanedBgTasksDead
+// to find on shutdown.
+
+const pending = new Map(); // taskId -> Set<Promise>
+
+export function trackBgWrite(taskId, promise) {
+  let set = pending.get(taskId);
+  if (!set) {
+    set = new Set();
+    pending.set(taskId, set);
+  }
+  const wrapped = Promise.resolve(promise).finally(() => set.delete(wrapped));
+  set.add(wrapped);
+}
+
+export async function flushBgWrites(taskId) {
+  const set = pending.get(taskId);
+  if (!set || set.size === 0) {
+    pending.delete(taskId);
+    return;
+  }
+  await Promise.allSettled([...set]);
+  pending.delete(taskId);
+}
+
+// Test helper. Not part of the public API.
+export function _pendingSize(taskId) {
+  return pending.get(taskId)?.size ?? 0;
+}

--- a/lib/spawner.js
+++ b/lib/spawner.js
@@ -35,6 +35,7 @@ import { agentSend } from "./agent-bus.js";
 import { getRunnerProfile } from "./runner-profiles.js";
 import { getThreadManager } from "./channels/thread-binding-manager.js";
 import { serverMsg, getServerLanguage } from "./i18n.js";
+import { trackBgWrite, flushBgWrites } from "./bg-write-tracker.js";
 
 // Callback for orchestrator — set via registerManagerTaskCallback to avoid circular imports
 let _onManagerTaskComplete = null;
@@ -907,7 +908,10 @@ This is the ONLY authoritative catalog. NEVER guess tool names or parameters. If
       // by the time we observe `task_started`.
       const toolUseId = event.tool_use_id;
       const pidFile = toolUseId ? `/tmp/yabby-bg/${toolUseId}.pid` : null;
-      (async () => {
+      // Tracked so the close handler can await this DB write before declaring
+      // bg tasks orphaned; otherwise a quick-exiting child can race past the
+      // createBgTask insert and leave the OS process unreferenced.
+      trackBgWrite(taskId, (async () => {
         let pid = null;
         if (pidFile) {
           for (let i = 0; i < 10; i++) {
@@ -943,7 +947,7 @@ This is the ONLY authoritative catalog. NEVER guess tool names or parameters. If
         } catch (err) {
           log(`[BG] createBgTask failed: ${err.message}`);
         }
-      })();
+      })());
     },
     onBgTaskNotification(event) {
       const cliTaskId = event.task_id;
@@ -953,14 +957,21 @@ This is the ONLY authoritative catalog. NEVER guess tool names or parameters. If
       log(`[TASK ${taskId}] BG_NOTIF: ${cliTaskId} → ${status}`);
       activityStream.write(`[${logTimestamp()}] BG_NOTIF: ${cliTaskId} → ${status}\n`);
       emitTaskEvent(taskId, "bg_notification", { cliTaskId, status, summary: event.summary });
-      import("../db/queries/bg-tasks.js").then(({ markBgTaskNotification }) =>
-        markBgTaskNotification(cliTaskId, {
-          status,
-          outputFile: event.output_file,
-          summary: event.summary,
-          usage: event.usage || null,
-        }).catch((err) => log(`[BG] markBgTaskNotification failed: ${err.message}`))
-      );
+      // Tracked so the close handler can await this DB write before
+      // markOrphanedBgTasksDead runs and before processHandles is cleared.
+      trackBgWrite(taskId, (async () => {
+        try {
+          const { markBgTaskNotification } = await import("../db/queries/bg-tasks.js");
+          await markBgTaskNotification(cliTaskId, {
+            status,
+            outputFile: event.output_file,
+            summary: event.summary,
+            usage: event.usage || null,
+          });
+        } catch (err) {
+          log(`[BG] markBgTaskNotification failed: ${err.message}`);
+        }
+      })());
       // A bg slot freed — re-evaluate the watchdog. When all tracked bg
       // jobs are done, this arms the 10s grace before terminating the CLI.
       // The bg-watcher (lib/bg-watcher.js) handles bridge enqueue centrally
@@ -1017,14 +1028,22 @@ This is the ONLY authoritative catalog. NEVER guess tool names or parameters. If
     // process group typically kills bg children too, but a detached (nohup)
     // child could survive; either way, we mark the DB row 'orphaned' so the
     // UI doesn't show stale 'running' entries forever.
-    import("../db/queries/bg-tasks.js")
-      .then(({ markOrphanedBgTasksDead }) => markOrphanedBgTasksDead(taskId))
-      .then((orphaned) => {
-        if (orphaned && orphaned.length > 0) {
-          log(`[TASK ${taskId}] marked ${orphaned.length} orphaned bg_tasks: ${orphaned.join(", ")}`);
-        }
-      })
-      .catch((err) => log(`[BG] markOrphanedBgTasksDead failed: ${err.message}`));
+    //
+    // CRITICAL ORDER: drain in-flight createBgTask / markBgTaskNotification
+    // writes first. Without this, a child that exits quickly after emitting
+    // bg_task_started can race past the createBgTask insert; then
+    // markOrphanedBgTasksDead finds no row to flag, processHandles is
+    // deleted, and the OS-level bg process is left untracked.
+    await flushBgWrites(taskId);
+    try {
+      const { markOrphanedBgTasksDead } = await import("../db/queries/bg-tasks.js");
+      const orphaned = await markOrphanedBgTasksDead(taskId);
+      if (orphaned && orphaned.length > 0) {
+        log(`[TASK ${taskId}] marked ${orphaned.length} orphaned bg_tasks: ${orphaned.join(", ")}`);
+      }
+    } catch (err) {
+      log(`[BG] markOrphanedBgTasksDead failed: ${err.message}`);
+    }
 
     rawStream.end();
     activityStream.end();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openyabby",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openyabby",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/routes/tasks.js
+++ b/routes/tasks.js
@@ -305,8 +305,16 @@ registerTaskControlRoute("pause", async (req, res) => {
   if (child) {
     try { killProcessTree(child, "SIGTERM"); } catch {}
 
-    // Clean up the handle after 3s (give the process time to terminate)
+    // After 3s grace, escalate to SIGKILL if the process is still tracked
+    // (close handler runs delete() only on actual exit). Without this
+    // escalation, a child that ignores SIGTERM survives the handle wipe and
+    // gets reparented to init — exactly the orphan signature that
+    // scripts/cleanup-zombies.sh exists to clean up.
     setTimeout(() => {
+      if (processHandles.has(task_id)) {
+        log(`[PAUSE] ${task_id} did not exit on SIGTERM — escalating to SIGKILL`);
+        try { killProcessTree(child, "SIGKILL"); } catch {}
+      }
       processHandles.delete(task_id);
       log(`[PAUSE] Cleaned up process handle for ${task_id}`);
     }, 3000);
@@ -397,13 +405,23 @@ registerTaskControlRoute("intervene", async (req, res) => {
       log(`[INTERVENE] Killing running task ${activeTaskId} (PID ${child.pid})`);
       try { killProcessTree(child, "SIGTERM"); } catch {}
 
-      // Wait briefly for the process to exit cleanly
-      await new Promise((resolve) => {
+      // Wait briefly for the process to exit cleanly. Resolve `true` on
+      // natural exit, `false` if the 2s hard timeout fires first — that
+      // distinction lets us escalate to SIGKILL instead of leaving an
+      // orphan reparented to init.
+      const exited = await new Promise((resolve) => {
         let done = false;
-        const onExit = () => { if (!done) { done = true; resolve(); } };
-        child.once("exit", onExit);
-        setTimeout(onExit, 2000); // Hard timeout 2s
+        const finish = (v) => { if (!done) { done = true; resolve(v); } };
+        child.once("exit", () => finish(true));
+        setTimeout(() => finish(false), 2000);
       });
+
+      if (!exited && processHandles.has(activeTaskId)) {
+        log(`[INTERVENE] ${activeTaskId} did not exit on SIGTERM — escalating to SIGKILL`);
+        try { killProcessTree(child, "SIGKILL"); } catch {}
+        // Brief grace so the kernel reaps before we resume the same taskId.
+        await new Promise((r) => setTimeout(r, 250));
+      }
 
       processHandles.delete(activeTaskId);
     }

--- a/tests/bg-write-tracker.test.js
+++ b/tests/bg-write-tracker.test.js
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+
+describe("bg-write-tracker", () => {
+  it("flushBgWrites resolves only after all tracked promises settle", async () => {
+    const { trackBgWrite, flushBgWrites } = await import("../lib/bg-write-tracker.js");
+
+    let resolveA;
+    let resolveB;
+    const settled = [];
+    const a = new Promise((r) => { resolveA = r; }).then(() => settled.push("a"));
+    const b = new Promise((r) => { resolveB = r; }).then(() => settled.push("b"));
+
+    trackBgWrite("task-1", a);
+    trackBgWrite("task-1", b);
+
+    let flushDone = false;
+    const flushPromise = flushBgWrites("task-1").then(() => { flushDone = true; });
+
+    await new Promise((r) => setTimeout(r, 10));
+    expect(flushDone).toBe(false);
+
+    resolveA();
+    await new Promise((r) => setTimeout(r, 10));
+    expect(flushDone).toBe(false);
+
+    resolveB();
+    await flushPromise;
+    expect(flushDone).toBe(true);
+    expect(settled).toEqual(["a", "b"]);
+  });
+
+  it("flushBgWrites tolerates rejected tracked promises (uses allSettled)", async () => {
+    const { trackBgWrite, flushBgWrites } = await import("../lib/bg-write-tracker.js");
+
+    const failing = Promise.reject(new Error("db down"));
+    failing.catch(() => {}); // prevent unhandled rejection
+    trackBgWrite("task-2", failing);
+
+    await expect(flushBgWrites("task-2")).resolves.toBeUndefined();
+  });
+
+  it("flushBgWrites with no tracked writes resolves immediately", async () => {
+    const { flushBgWrites } = await import("../lib/bg-write-tracker.js");
+    await expect(flushBgWrites("task-never-tracked")).resolves.toBeUndefined();
+  });
+
+  it("tracker entries are scoped per taskId", async () => {
+    const { trackBgWrite, flushBgWrites } = await import("../lib/bg-write-tracker.js");
+
+    let resolveOther;
+    const other = new Promise((r) => { resolveOther = r; });
+    trackBgWrite("task-A", other);
+
+    // Flushing a different taskId should not wait for task-A's promise.
+    await expect(flushBgWrites("task-B")).resolves.toBeUndefined();
+
+    // Cleanup so the promise doesn't dangle.
+    resolveOther();
+    await flushBgWrites("task-A");
+  });
+
+  it("flushBgWrites clears tracked promises after settling", async () => {
+    const { trackBgWrite, flushBgWrites, _pendingSize } = await import("../lib/bg-write-tracker.js");
+
+    trackBgWrite("task-3", Promise.resolve());
+    trackBgWrite("task-3", Promise.resolve());
+    expect(_pendingSize("task-3")).toBe(2);
+
+    await flushBgWrites("task-3");
+    expect(_pendingSize("task-3")).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Two related fixes for the recurring problem of orphaned `claude` processes lingering with `ppid=1` (the empirical signature `scripts/cleanup-zombies.sh` exists to mop up).

### 1. Spawner: await in-flight bg-task DB writes before marking orphans

Three fire-and-forget DB writes in `lib/spawner.js` could leave bg-task tracking inconsistent:

- `onBgTaskStarted` launched an async IIFE that called `createBgTask` but was never awaited
- `onBgTaskNotification` fired `markBgTaskNotification` via a stray `.then(...)` with no caller waiting
- The close handler called `markOrphanedBgTasksDead` in a promise chain and immediately ran `processHandles.delete`, so handles cleared before the orphan-mark query finished

Net effect: a quick-exiting child could race past its own `createBgTask` insert, leaving no DB row for `markOrphanedBgTasksDead` to flag — the OS bg process kept running but bookkeeping lost track of it.

**Fix:** new `lib/bg-write-tracker.js` — a per-task `Set<Promise>` of in-flight bg-task writes. The spawner's close handler now `await flushBgWrites(taskId)` then `await markOrphanedBgTasksDead(...)` before `processHandles.delete`. Tests: `tests/bg-write-tracker.test.js` covers ordering, rejection tolerance, empty fast-path, taskId scoping, and cleanup (5 tests).

### 2. Tasks API: escalate SIGTERM to SIGKILL on pause / intervene

`POST /api/tasks/pause` and `POST /api/tasks/intervene` sent SIGTERM and then deleted the process handle a few seconds later **unconditionally** — no SIGKILL fallback. A child that ignored SIGTERM (hung Bash, stuck Playwright tab, slow MCP shutdown) would survive the handle wipe, get reparented to init, and become the exact orphan that `cleanup-zombies.sh` greps for:

```bash
ps -eo pid,ppid,command | awk '$2==1 && $3=="claude"'
```

**Fix:** both endpoints now mirror the FINAL_OUTPUT watchdog pattern from `lib/spawner.js` — after the SIGTERM grace, if `processHandles` still tracks the task, send `killProcessTree(child, "SIGKILL")` before deleting the handle.

## What this PR does NOT address (deliberately deferred)

Each of these came up in investigation and was scoped out — they need their own PRs:

- **MCP grandchildren** (`lib/mcp/client.js`): the SDK already does proper SIGTERM→2s→SIGKILL on the direct child, but spawns without `detached:true`. Tools like Playwright/Chromium fork their own children that survive a direct-PID kill. Fixing this needs either a `patch-package` patch to `@modelcontextprotocol/sdk` or a recursive process-tree walk.
- **TTS spawns without `detached:true`** (`lib/tts/edge-tts.js`, `lib/tts/system.js`): only orphans on Node SIGKILL mid-playback. Narrow impact, deserves a small tracked-children-Set fix in shutdown.
- **Scheduler max-runtime watchdog** (`lib/scheduler.js`): policy change — needs a config knob (`tasks.maxScheduledRuntimeMs`) with a sensible default. Not a one-liner.

## Test plan

- [x] `npx vitest run` — 50 passing (5 new). 7 failures in `tests/conversation-windowing.test.js` are pre-existing on `main` (file tries to hit a real Postgres instead of mocking).
- [ ] **Manual: pause a stuck task.** Trigger a task that hangs Bash (e.g. `bash -c "trap '' TERM; sleep 9999"`). `POST /api/tasks/pause`. Expect: SIGTERM logged, then 3s later `[PAUSE] <id> did not exit on SIGTERM — escalating to SIGKILL`, then the process is gone (`ps -ef | grep <pid>` returns nothing).
- [ ] **Manual: intervene on a stuck task.** Same setup, call `yabby_intervention`. Expect: same escalation log line for intervene, and the new task resumes cleanly with the same `taskId` / `sessionId`.
- [ ] **Manual: bg-task race.** Run a task that emits `bg_task_started` then exits quickly (sub-second). Check `bg_tasks` table — the row should exist and be marked `orphaned` (not missing).
- [ ] **Regression: normal task lifecycle.** Spawn a normal task that completes naturally. Confirm `bg_tasks` rows go to `completed` not `orphaned`, and no `[BG] markOrphanedBgTasksDead failed` lines appear.
- [ ] **Regression: `scripts/cleanup-zombies.sh`.** After exercising the above paths, the script should find 0 orphans (where previously it found some).

🤖 Generated with [Claude Code](https://claude.com/claude-code)