### PR TITLE
fix(setup): default to docker, validate pg auth, preflight python sidecars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,14 +16,16 @@ OPENAI_API_KEY=sk-...
 # ---------- PostgreSQL ----------
 # Source of truth for all persistent state (tasks, agents, conversations).
 # `./setup.sh` will start a local Postgres via Docker if you don't have one.
-# In Docker mode, setup.sh defaults the host port to 5433 (to avoid clashing
-# with a local Postgres on 5432) and rewrites PG_PORT here accordingly.
+# Defaults below match the Docker container (port 5433 to avoid clashing with
+# a local Postgres on 5432; user/password "yabby" matching docker-compose.yml).
+# If you want to use your own local Postgres, run `./setup.sh local` and edit
+# PG_USER / PG_PASSWORD / PG_PORT to match it.
 
 PG_HOST=localhost
-PG_PORT=5432
+PG_PORT=5433
 PG_DATABASE=yabby
-PG_USER=postgres
-PG_PASSWORD=
+PG_USER=yabby
+PG_PASSWORD=yabby
 
 # Postgres SSL — set to "true" for cloud providers (Neon, Supabase, AWS RDS).
 # Leave unset or "false" for local Postgres without SSL.
@@ -35,7 +37,7 @@ PG_SSL=
 # In Docker mode, setup.sh defaults the host port to 6380 (to avoid clashing
 # with a local Redis on 6379) and rewrites REDIS_URL here accordingly.
 
-REDIS_URL=redis://localhost:6379
+REDIS_URL=redis://localhost:6380
 
 
 # ---------- Claude CLI ----------

--- a/README.md
+++ b/README.md
@@ -123,8 +123,9 @@ If you want a minimal consumer voice app, this is probably too much. If you want
 | Requirement | Version |
 |-------------|---------|
 | Node.js | 20+ |
-| PostgreSQL | 14+ (database: `yabby`) |
-| Redis | 6+ (`localhost:6379`) |
+| Docker | Recommended — provides PostgreSQL 16 + Redis 7 via `./setup.sh` |
+| PostgreSQL | 14+ (only if you opt out of Docker via `./setup.sh local`) |
+| Redis | 6+ (only if you opt out of Docker via `./setup.sh local`) |
 | Claude CLI | `npm i -g @anthropic-ai/claude-code` |
 | OpenAI API key | Realtime API access |
 
@@ -425,8 +426,10 @@ Common issues and quick fixes. For deeper coverage see [docs/troubleshooting.md]
 |---|---|---|
 | `EADDRINUSE: port 3000` on startup | A previous Node instance is still bound | `lsof -ti :3000 \| xargs kill` then `npm start` |
 | `Claude CLI not found` in spawner logs | CLI not on `PATH`, or installed under a different name | `npm i -g @anthropic-ai/claude-code`, or set `CLAUDE_CMD=/full/path/to/claude` in `.env` |
-| `ECONNREFUSED 127.0.0.1:5432` | PostgreSQL is not running | `./setup.sh docker` or start your local Postgres; verify `PG_*` in `.env` match |
-| `ECONNREFUSED 127.0.0.1:6379` | Redis is not running | `./setup.sh docker`, or `brew services start redis` if installed locally |
+| `ECONNREFUSED 127.0.0.1:5433` (or `:5432` in local mode) | PostgreSQL container/service is not running | `./setup.sh docker` to start, or verify `PG_HOST`/`PG_PORT` in `.env` match your local Postgres |
+| `role "..." does not exist` on startup | App is talking to the wrong Postgres (e.g. brew Postgres on 5432 without a `yabby` role) | `./setup.sh docker` (recommended), or create the role manually: `createuser -s yabby && createdb -O yabby yabby` |
+| `ECONNREFUSED 127.0.0.1:6380` (or `:6379` in local mode) | Redis container/service is not running | `./setup.sh docker`, or `brew services start redis` and set `REDIS_URL=redis://localhost:6379` in `.env` |
+| `[ImageGen] ⏭ Skipped: ...` in dev logs | Imagegen preflight failed (non-Apple-Silicon, Python <3.10, low disk, or offline) | Optional — fix the reason shown in the skip line, or ignore if you don't need local image generation |
 | Wake word never triggers | Speaker service is off, or you haven't enrolled | Service is **fail-open** (still works without it). Run `npm run speaker` and enroll via the UI for biometric filtering |
 | Tunnel won't connect to `relay.openyabby.com` | No `RELAY_SECRET`, or you don't want a tunnel | Set `DISABLE_TUNNEL=true` in `.env` to silence; the app runs fine locally without it |
 | Tasks pause with status `paused_llm_limit` | Claude CLI hit its daily quota | Yabby auto-resumes after the reset window. See [migration 024](db/migrations/024_llm_limit_tasks.js) for the persisted resume metadata |

--- a/README.md
+++ b/README.md
@@ -137,7 +137,12 @@ cd OpenYabby
 # -> http://localhost:3000
 ```
 
-The setup script handles everything: prerequisites check, `npm install`, `.env` creation (prompts for your OpenAI API key), infrastructure startup (Docker or local), and server launch. Run `./setup.sh docker` to use Docker Compose for PostgreSQL + Redis, or `./setup.sh local` if they're already running.
+The setup script handles everything: prerequisites check, `npm install`, `.env` creation (prompts for your OpenAI API key), infrastructure startup, and server launch. `./setup.sh` (no arg) defaults to **Docker mode** — Yabby's Postgres + Redis run in containers on non-default ports (`5433` / `6380`) so they never collide with your own local services. Pass `./setup.sh local` if you'd rather point Yabby at your own Postgres + Redis (you'll need to edit `.env` to match).
+
+**Optional add-ons** (auto-skip with a clear notice if requirements aren't met):
+
+- **Image generation** — Apple Silicon only, requires Python 3.10+ and ~8 GB free disk. The `generate_image` tool is unavailable on Intel/Linux/old-Python; `[ImageGen] ⏭ Skipped: ...` appears in the logs explaining why.
+- **Speaker verification** — voice biometric filtering. Requires Python 3.10+. Wake word still works without it (fail-open).
 
 ### Manual Setup
 

--- a/imagegen/start.sh
+++ b/imagegen/start.sh
@@ -1,29 +1,84 @@
 #!/bin/bash
 
 # Yabby Image Generation Sidecar Startup Script
-# Starts the Python FastAPI service on port 3002
-# Requires macOS with Apple Silicon (M1/M2/M3/M4)
+# Starts the Python FastAPI service on port 3002.
+# Skips cleanly (exit 0) if requirements aren't met, so `concurrently`
+# treats it as an optional component instead of a crash.
 
 cd "$(dirname "$0")"
 
-# Check platform
-if [[ "$(uname -s)" != "Darwin" ]]; then
-  echo "[ImageGen] ⚠ Not running on macOS — image generation is Apple-only"
-  echo "[ImageGen] Sidecar will NOT start. Generate_image tool will be unavailable."
+skip() {
+  echo ""
+  echo "[ImageGen] ⏭  Skipped: $1"
+  echo "[ImageGen]    The generate_image tool will be unavailable."
+  echo "[ImageGen]    Fix the cause above and re-run \`npm run dev\` (or \`npm run imagegen\`) to enable."
+  echo ""
   exit 0
+}
+
+# ── Preflight checks ─────────────────────────────────────
+# Each fails fast with a one-line reason so the user knows exactly why
+# imagegen didn't start (instead of watching a slow pip install on the
+# wrong Python or falling back to CPU inference).
+
+# 1. macOS only (host-native because MPS isn't available in Docker)
+[[ "$(uname -s)" == "Darwin" ]] || skip "requires macOS (got $(uname -s)). Image generation uses Apple Metal (MPS)."
+
+# 2. Apple Silicon only — Intel Macs don't have MPS
+[[ "$(uname -m)" == "arm64" ]] || skip "requires Apple Silicon (got $(uname -m)). M1/M2/M3/M4 only."
+
+# 3. Python 3.10+ — Xcode CLT ships Python 3.9 which is too old for current
+#    torch wheels and triggers the slow pip 21.2.4 path. Auto-pick the
+#    newest available interpreter from common locations.
+PY_BIN=""
+for cand in python3.13 python3.12 python3.11 python3.10; do
+  if command -v "$cand" >/dev/null 2>&1; then
+    PY_BIN="$(command -v "$cand")"
+    break
+  fi
+done
+
+# Fall back to bare `python3` only if it's actually >= 3.10
+if [ -z "$PY_BIN" ] && command -v python3 >/dev/null 2>&1; then
+  if python3 -c 'import sys; sys.exit(0 if sys.version_info >= (3,10) else 1)' 2>/dev/null; then
+    PY_BIN="$(command -v python3)"
+  fi
 fi
 
-echo "[ImageGen] Checking Python dependencies..."
+if [ -z "$PY_BIN" ]; then
+  skip "Python 3.10+ not found. Install with: brew install python@3.12"
+fi
 
+PY_VER=$("$PY_BIN" -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")' 2>/dev/null || echo "unknown")
+echo "[ImageGen] Using $PY_BIN (Python $PY_VER)"
+
+# 4. Disk space ≥ 8 GB (torch wheels + diffusers + SDXL weights)
+FREE_GB=$(df -g . 2>/dev/null | awk 'NR==2 {print $4}')
+if [ -n "$FREE_GB" ] && [ "$FREE_GB" -lt 8 ]; then
+  skip "needs ≥8 GB free disk for model weights (have ${FREE_GB} GB)"
+fi
+
+# 5. Hugging Face reachable (first run downloads model weights from there)
+if ! curl -sf --max-time 3 -o /dev/null https://huggingface.co 2>/dev/null; then
+  skip "huggingface.co unreachable — check your internet connection"
+fi
+
+# ── Install + run ────────────────────────────────────────
 if [ ! -d "venv" ]; then
-  echo "[ImageGen] Creating virtual environment..."
-  python3 -m venv venv
+  echo "[ImageGen] Creating virtual environment with $PY_BIN..."
+  "$PY_BIN" -m venv venv || skip "failed to create venv (check Python install)"
 fi
 
+# shellcheck source=/dev/null
 source venv/bin/activate
 
+echo "[ImageGen] Upgrading pip..."
+pip install -q --upgrade pip >/dev/null 2>&1 || true
+
 echo "[ImageGen] Installing dependencies..."
-pip install -q -r requirements.txt
+if ! pip install -q -r requirements.txt; then
+  skip "pip install failed — see output above"
+fi
 
 echo "[ImageGen] Starting image generation service on port 3002..."
-uvicorn server:app --host 0.0.0.0 --port 3002 --reload
+exec uvicorn server:app --host 0.0.0.0 --port 3002 --reload

--- a/scripts/ensure-services.sh
+++ b/scripts/ensure-services.sh
@@ -2,110 +2,140 @@
 # ═══════════════════════════════════════════════════════
 # Ensure PostgreSQL + Redis are running before Yabby starts
 # ═══════════════════════════════════════════════════════
-# Detects the environment (Homebrew / Docker) and starts
-# the services if they're not already up. Idempotent.
+# Honors .env so it probes the *configured* server with the
+# *configured* credentials — not just whatever happens to be
+# listening on the default ports. This prevents silently
+# hijacking a different Postgres that doesn't have our role.
 
 set -e
 
-# Check Redis
-if ! redis-cli ping > /dev/null 2>&1; then
-  echo "⚠️  Redis not running — attempting to start..."
-  if command -v brew >/dev/null 2>&1 && brew services list 2>/dev/null | grep -q "^redis"; then
-    brew services start redis > /dev/null 2>&1 || true
-    # Wait up to 5s for Redis to come up
-    for i in {1..10}; do
-      sleep 0.5
-      redis-cli ping > /dev/null 2>&1 && break
-    done
+# ── Resolve project root (script lives in scripts/) ──
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$ROOT_DIR"
+
+# ── Load .env so we use the configured ports/creds ──
+if [ -f .env ]; then
+  set -a
+  # shellcheck disable=SC1091
+  . ./.env 2>/dev/null || true
+  set +a
+fi
+
+PG_HOST="${PG_HOST:-localhost}"
+PG_PORT="${PG_PORT:-5433}"
+PG_DB="${PG_DATABASE:-yabby}"
+PG_USER_NAME="${PG_USER:-yabby}"
+REDIS_URL_VAL="${REDIS_URL:-redis://localhost:6380}"
+REDIS_HOST=$(echo "$REDIS_URL_VAL" | sed 's|redis://||' | cut -d: -f1)
+REDIS_PORT=$(echo "$REDIS_URL_VAL" | sed 's|redis://||' | cut -d: -f2 | cut -d/ -f1)
+
+# Who's holding a TCP port? (best-effort, macOS/Linux)
+who_owns_port() {
+  lsof -nP -iTCP:"$1" -sTCP:LISTEN 2>/dev/null | awk 'NR==2 {print $1" (pid "$2")"}'
+}
+
+# ── Redis ──
+if ! redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" ping > /dev/null 2>&1; then
+  echo "⚠️  Redis not reachable at ${REDIS_HOST}:${REDIS_PORT} — attempting to start..."
+
+  # Prefer the Docker container yabby provisioned
+  if command -v docker >/dev/null 2>&1 && docker compose ps redis 2>/dev/null | grep -q redis; then
+    docker compose up -d redis > /dev/null 2>&1 || true
+    sleep 2
   elif command -v docker >/dev/null 2>&1 && docker ps -a --format '{{.Names}}' | grep -q '^yabby-redis$'; then
     docker start yabby-redis > /dev/null 2>&1 || true
     sleep 2
+  elif command -v brew >/dev/null 2>&1 && brew services list 2>/dev/null | grep -q "^redis"; then
+    brew services start redis > /dev/null 2>&1 || true
+    for i in {1..10}; do sleep 0.5; redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" ping > /dev/null 2>&1 && break; done
   fi
 
-  if redis-cli ping > /dev/null 2>&1; then
-    echo "✅ Redis started"
-  else
-    echo "❌ Redis failed to start — install via: brew install redis && brew services start redis"
+  if ! redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" ping > /dev/null 2>&1; then
+    OWNER=$(who_owns_port "$REDIS_PORT")
+    echo "❌ Redis failed to start at ${REDIS_HOST}:${REDIS_PORT}"
+    if [ -n "$OWNER" ]; then
+      echo "   Port $REDIS_PORT is held by: $OWNER (but not responding to PING)"
+    fi
+    echo ""
+    echo "   Fix one of:"
+    echo "     - Start the Docker container:  ./setup.sh docker"
+    echo "     - Or point .env REDIS_URL at your own Redis instance"
     exit 1
   fi
-else
-  echo "✅ Redis already running"
 fi
+echo "✅ Redis ${REDIS_HOST}:${REDIS_PORT} ready"
 
-# Check PostgreSQL
-PG_DB="${PG_DATABASE:-yabby}"
-PG_USER_NAME="${PG_USER:-yabby}"
+# ── PostgreSQL: reachability ──
+if ! pg_isready -h "$PG_HOST" -p "$PG_PORT" -q > /dev/null 2>&1; then
+  echo "⚠️  PostgreSQL not reachable at ${PG_HOST}:${PG_PORT} — attempting to start..."
 
-if ! pg_isready -q > /dev/null 2>&1; then
-  echo "⚠️  PostgreSQL not running — attempting to start..."
-  if command -v brew >/dev/null 2>&1; then
-    # 1) Prefer a version that was already running before (has "started" status)
-    # 2) Otherwise, prefer the version that actually holds the yabby database
-    #    (check each version's data dir via pg_ctl before touching brew services)
-    # 3) Fallback: first installed version in the standard order
-    PG_TO_START=""
-
-    # Check if any version has "started" state (was running previously)
-    PG_TO_START=$(brew services list 2>/dev/null | awk '$2=="started" && $1 ~ /^postgresql/ {print $1; exit}')
-
-    # If none was started, find the one holding the yabby DB by scanning data dirs
-    if [ -z "$PG_TO_START" ]; then
-      for pg_version in postgresql@14 postgresql@15 postgresql@16 postgresql@17 postgresql; do
-        if brew services list 2>/dev/null | grep -q "^${pg_version} "; then
-          data_dir="$(brew --prefix)/var/${pg_version}"
-          # postgresql@14 default data dir
-          [ ! -d "$data_dir" ] && data_dir="$(brew --prefix)/var/postgres"
-          if [ -d "$data_dir" ] && [ -f "$data_dir/base" ] || ls "$data_dir"/base 2>/dev/null | grep -q .; then
-            # This version has data — prefer it
-            PG_TO_START="$pg_version"
-            break
-          fi
-        fi
-      done
-    fi
-
-    # Last resort: first installed version
-    if [ -z "$PG_TO_START" ]; then
-      PG_TO_START=$(brew services list 2>/dev/null | awk '$1 ~ /^postgresql/ {print $1; exit}')
-    fi
-
-    if [ -n "$PG_TO_START" ]; then
-      echo "   Starting $PG_TO_START..."
-      brew services start "$PG_TO_START" > /dev/null 2>&1 || true
-    fi
-
-    # Wait up to 10s for PG to come up
-    for i in {1..20}; do
-      sleep 0.5
-      pg_isready -q > /dev/null 2>&1 && break
-    done
+  # Prefer Docker if compose knows about a postgres service
+  if command -v docker >/dev/null 2>&1 && docker compose ps postgres 2>/dev/null | grep -q postgres; then
+    docker compose up -d postgres > /dev/null 2>&1 || true
+    for i in {1..30}; do sleep 0.5; pg_isready -h "$PG_HOST" -p "$PG_PORT" -q > /dev/null 2>&1 && break; done
   elif command -v docker >/dev/null 2>&1 && docker ps -a --format '{{.Names}}' | grep -q '^yabby-postgres$'; then
     docker start yabby-postgres > /dev/null 2>&1 || true
-    sleep 3
+    for i in {1..30}; do sleep 0.5; pg_isready -h "$PG_HOST" -p "$PG_PORT" -q > /dev/null 2>&1 && break; done
   fi
 
-  if pg_isready -q > /dev/null 2>&1; then
-    echo "✅ PostgreSQL started"
-  else
-    echo "❌ PostgreSQL failed to start — install via: brew install postgresql@14 && brew services start postgresql@14"
+  if ! pg_isready -h "$PG_HOST" -p "$PG_PORT" -q > /dev/null 2>&1; then
+    OWNER=$(who_owns_port "$PG_PORT")
+    echo "❌ PostgreSQL failed to start at ${PG_HOST}:${PG_PORT}"
+    if [ -n "$OWNER" ]; then
+      echo "   Port $PG_PORT is held by: $OWNER (but not responding to pg_isready)"
+    fi
+    echo ""
+    echo "   Fix one of:"
+    echo "     - Start the Docker container:  ./setup.sh docker"
+    echo "     - Or point .env PG_HOST/PG_PORT at your own Postgres"
     exit 1
   fi
-else
-  echo "✅ PostgreSQL already running"
 fi
 
-# Ensure the yabby role exists (try both current user and postgres super)
-ROLE_EXISTS=$(psql -tAc "SELECT 1 FROM pg_roles WHERE rolname='$PG_USER_NAME'" postgres 2>/dev/null || \
-              psql -U "$(whoami)" -tAc "SELECT 1 FROM pg_roles WHERE rolname='$PG_USER_NAME'" postgres 2>/dev/null)
-if [ "$ROLE_EXISTS" != "1" ]; then
-  echo "⚠️  Role '$PG_USER_NAME' not found — creating..."
-  createuser -s "$PG_USER_NAME" 2>/dev/null || echo "   (createuser failed — may need manual setup)"
+# ── PostgreSQL: authentication ──
+# A listener answering pg_isready isn't enough — verify the *configured* user
+# can actually authenticate. This catches the common case where a different
+# Postgres (e.g. brew Postgres on 5432) is squatting on the port but has no
+# matching role.
+AUTH_OK=$(PGPASSWORD="${PG_PASSWORD:-}" psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER_NAME" -d postgres -tAc 'SELECT 1' 2>&1 || true)
+
+if [ "$AUTH_OK" != "1" ]; then
+  # Try to auto-create the role and DB if we're talking to a local Postgres
+  # where the current shell user is a superuser (common dev setup).
+  echo "⚠️  PostgreSQL at ${PG_HOST}:${PG_PORT} doesn't accept '$PG_USER_NAME' — attempting auto-fix..."
+  createuser -h "$PG_HOST" -p "$PG_PORT" -s "$PG_USER_NAME" 2>/dev/null || true
+  if [ -n "${PG_PASSWORD:-}" ]; then
+    psql -h "$PG_HOST" -p "$PG_PORT" -d postgres -c "ALTER USER \"$PG_USER_NAME\" WITH PASSWORD '$PG_PASSWORD'" >/dev/null 2>&1 || true
+  fi
+  createdb -h "$PG_HOST" -p "$PG_PORT" -O "$PG_USER_NAME" "$PG_DB" 2>/dev/null || true
+
+  AUTH_OK=$(PGPASSWORD="${PG_PASSWORD:-}" psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER_NAME" -d postgres -tAc 'SELECT 1' 2>&1 || true)
 fi
 
-# Ensure the yabby database exists (best-effort, ignore if already exists)
-if ! psql -U "$PG_USER_NAME" -lqt 2>/dev/null | cut -d \| -f 1 | grep -qw "$PG_DB"; then
+if [ "$AUTH_OK" != "1" ]; then
+  OWNER=$(who_owns_port "$PG_PORT")
+  echo ""
+  echo "❌ PostgreSQL on ${PG_HOST}:${PG_PORT} won't accept user '$PG_USER_NAME'."
+  if [ -n "$OWNER" ]; then
+    echo "   Port $PG_PORT is held by: $OWNER"
+    echo "   Likely a different Postgres is squatting on the port and doesn't have the '$PG_USER_NAME' role."
+  fi
+  echo ""
+  echo "   Fix one of:"
+  echo "     1) Use Docker Postgres (recommended):    ./setup.sh docker"
+  echo "     2) Create the role manually:             createuser -s $PG_USER_NAME && createdb -O $PG_USER_NAME $PG_DB"
+  echo "     3) Edit .env to use your existing user:  PG_USER=$(whoami) PG_PASSWORD=<your-pwd>"
+  exit 1
+fi
+
+# ── Ensure the target database exists (best-effort) ──
+DB_EXISTS=$(PGPASSWORD="${PG_PASSWORD:-}" psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER_NAME" -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname='$PG_DB'" 2>/dev/null || true)
+if [ "$DB_EXISTS" != "1" ]; then
   echo "⚠️  Database '$PG_DB' not found — creating..."
-  createdb -O "$PG_USER_NAME" "$PG_DB" 2>/dev/null || echo "   (createdb failed — may need manual setup)"
+  PGPASSWORD="${PG_PASSWORD:-}" createdb -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER_NAME" -O "$PG_USER_NAME" "$PG_DB" 2>/dev/null \
+    || echo "   (createdb failed — server will retry on startup)"
 fi
 
+echo "✅ PostgreSQL ${PG_HOST}:${PG_PORT} accepting '$PG_USER_NAME'"
 echo "🚀 Services ready"

--- a/server.js
+++ b/server.js
@@ -882,8 +882,25 @@ async function startup() {
       const { run } = await import(`./db/migrations/${migFile}`);
       await run();
     } catch (err) {
-      if (!err.message.includes("already exists") && !err.message.includes("duplicate")) {
-        log(`[STARTUP] Migration ${migFile} note:`, err.message);
+      // Connection / auth / missing-DB errors: fail fast with a single clear
+      // message instead of logging 40+ "note:" lines and crashing later. These
+      // mean the app is talking to the wrong Postgres (or a Postgres that
+      // doesn't have the configured role/database).
+      const msg = err.message || "";
+      const fatal =
+        /role .* does not exist/i.test(msg) ||
+        /database .* does not exist/i.test(msg) ||
+        /password authentication failed/i.test(msg) ||
+        /connection refused|ECONNREFUSED/i.test(msg) ||
+        /server closed the connection/i.test(msg);
+      if (fatal) {
+        log(`[STARTUP] ❌ Cannot run migration ${migFile}: ${msg}`);
+        log(`[STARTUP]    Yabby is talking to the wrong Postgres or missing role/database.`);
+        log(`[STARTUP]    Fix: ./setup.sh docker   (or edit .env to point at a valid Postgres)`);
+        process.exit(1);
+      }
+      if (!msg.includes("already exists") && !msg.includes("duplicate")) {
+        log(`[STARTUP] Migration ${migFile} note:`, msg);
       }
     }
   }

--- a/setup.sh
+++ b/setup.sh
@@ -62,21 +62,12 @@ success "npm $(npm -v) detected"
 # ══════════════════════════════════════════════════════════
 header "Infrastructure Mode"
 
-MODE="${1:-}"
+MODE="${1:-docker}"
 MODE_EXPLICIT=true
-if [ -z "$MODE" ]; then
+if [ $# -eq 0 ]; then
     MODE_EXPLICIT=false
-    echo "How would you like to run PostgreSQL and Redis?"
-    echo ""
-    echo "  ${BOLD}1) docker${NC}  — Use Docker Compose (recommended, zero config)"
-    echo "  ${BOLD}2) local${NC}   — Use locally installed PostgreSQL + Redis"
-    echo ""
-    read -rp "Choose [1/2]: " choice
-    case "$choice" in
-        1|docker)  MODE="docker" ;;
-        2|local)   MODE="local" ;;
-        *)         MODE="docker"; warn "Defaulting to docker mode" ;;
-    esac
+    info "No mode specified — defaulting to ${BOLD}docker${NC} (recommended)"
+    info "Run ${BOLD}./setup.sh local${NC} if you'd rather use your own PostgreSQL + Redis"
 fi
 
 # Returns first free TCP port >= $1 (max 100 attempts). Used to pre-fill
@@ -159,11 +150,17 @@ if [ -f ".env" ]; then
     success ".env file already exists — skipping creation"
     info "To reconfigure, edit .env manually or delete it and re-run setup"
 
-    # Ensure Docker PG credentials match docker-compose.yml
+    # Reconcile Docker creds even on re-run — earlier setup.sh versions only
+    # patched PG_PASSWORD, so stale PG_USER=postgres / PG_PORT=5432 from
+    # .env.example would silently misroute the app to whatever Postgres is
+    # on :5432 (e.g. brew Postgres without a "postgres" role → migration
+    # crashes with `role "postgres" does not exist`).
     if [ "$MODE" = "docker" ]; then
-        sed -i.bak "s/^PG_PASSWORD=$/PG_PASSWORD=yabby/" .env
+        sed -i.bak "s/^PG_USER=.*/PG_USER=yabby/" .env
+        sed -i.bak "s/^PG_PASSWORD=.*/PG_PASSWORD=yabby/" .env
+        sed -i.bak "s/^PG_DATABASE=.*/PG_DATABASE=yabby/" .env
         rm -f .env.bak
-        info "Verified PG_PASSWORD is set for Docker mode"
+        info "Reconciled PG_USER / PG_PASSWORD / PG_DATABASE for Docker mode"
     fi
 else
     info "Creating .env from .env.example..."
@@ -256,7 +253,18 @@ if [ "$MODE" = "docker" ]; then
     fi
 
     info "Starting PostgreSQL + Redis via Docker Compose..."
-    docker compose up -d postgres redis
+    if ! docker compose up -d postgres redis 2>&1 | tee /tmp/yabby-compose.log; then
+        if grep -qE "ports are not available|address already in use|port is already allocated" /tmp/yabby-compose.log; then
+            NEW_PG=$(find_free_port $((YABBY_PG_PORT + 1)))
+            NEW_REDIS=$(find_free_port $((YABBY_REDIS_PORT + 1)))
+            error "Port conflict starting Docker services."
+            echo "  Re-run with free ports:"
+            echo "    YABBY_PG_PORT=$NEW_PG YABBY_REDIS_PORT=$NEW_REDIS ./setup.sh docker"
+            exit 1
+        fi
+        error "docker compose up failed — see /tmp/yabby-compose.log"
+        exit 1
+    fi
 
     info "Waiting for services to be healthy..."
     # Wait for PostgreSQL

--- a/speaker/start.sh
+++ b/speaker/start.sh
@@ -1,26 +1,63 @@
 #!/bin/bash
 
 # Yabby Speaker Verification Service Startup Script
-# Starts the Python FastAPI service on port 3001
+# Starts the Python FastAPI service on port 3001.
+# Skips cleanly (exit 0) if Python isn't usable, so concurrently
+# treats it as an optional component instead of a crash.
 
 cd "$(dirname "$0")"
 
-echo "[Speaker] Checking Python dependencies..."
+skip() {
+  echo ""
+  echo "[Speaker] ⏭  Skipped: $1"
+  echo "[Speaker]    Wake-word voice biometrics will be disabled (fail-open)."
+  echo "[Speaker]    Fix the cause above and re-run \`npm run dev\` to enable."
+  echo ""
+  exit 0
+}
 
-# Check if virtual environment exists
-if [ ! -d "venv" ]; then
-  echo "[Speaker] Creating virtual environment..."
-  python3 -m venv venv
+# ── Preflight: pick a usable Python ≥ 3.10 ───────────────
+# Xcode CLT ships Python 3.9 which is too old for current speechbrain/torch
+# wheels and triggers the slow pip 21.2.4 path. Auto-pick the newest
+# available interpreter from common locations.
+PY_BIN=""
+for cand in python3.13 python3.12 python3.11 python3.10; do
+  if command -v "$cand" >/dev/null 2>&1; then
+    PY_BIN="$(command -v "$cand")"
+    break
+  fi
+done
+
+if [ -z "$PY_BIN" ] && command -v python3 >/dev/null 2>&1; then
+  if python3 -c 'import sys; sys.exit(0 if sys.version_info >= (3,10) else 1)' 2>/dev/null; then
+    PY_BIN="$(command -v python3)"
+  fi
 fi
 
-# Activate virtual environment
+if [ -z "$PY_BIN" ]; then
+  skip "Python 3.10+ not found. Install with: brew install python@3.12"
+fi
+
+PY_VER=$("$PY_BIN" -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")' 2>/dev/null || echo "unknown")
+echo "[Speaker] Using $PY_BIN (Python $PY_VER)"
+
+# ── Install + run ────────────────────────────────────────
+if [ ! -d "venv" ]; then
+  echo "[Speaker] Creating virtual environment with $PY_BIN..."
+  "$PY_BIN" -m venv venv || skip "failed to create venv (check Python install)"
+fi
+
+# shellcheck source=/dev/null
 source venv/bin/activate
 
-# Install/update dependencies
-echo "[Speaker] Installing dependencies..."
-pip install -q -r requirements.txt
+echo "[Speaker] Upgrading pip..."
+pip install -q --upgrade pip >/dev/null 2>&1 || true
 
-# Start service
+echo "[Speaker] Installing dependencies..."
+if ! pip install -q -r requirements.txt; then
+  skip "pip install failed — see output above"
+fi
+
 echo "[Speaker] Starting speaker verification service on port 3001..."
 echo "[Speaker] Enrollment UI: http://localhost:3000/settings (Speaker Verification tab)"
-uvicorn app:app --host 0.0.0.0 --port 3001 --reload
+exec uvicorn app:app --host 0.0.0.0 --port 3001 --reload


### PR DESCRIPTION
## Summary

Fixes the "too hard to setup" failure path reported by a new macOS user (`role "postgres" does not exist` crash + slow imagegen pip install on Python 3.9). Root causes were stale `.env.example` defaults and overly trusting service-detection scripts.

### What changed

- **`.env.example`** now matches the Docker container (`PG_PORT=5433`, `PG_USER=yabby`, `PG_PASSWORD=yabby`, `REDIS_URL=…:6380`). Previously defaulted to `:5432` / `postgres` user, which silently hijacked Homebrew Postgres on macOS — a Postgres that doesn't create a `postgres` role.
- **`scripts/ensure-services.sh`** sources `.env`, probes the *configured* host:port with the *configured* user via `psql`, identifies port squatters via `lsof`, auto-creates the role/DB when current shell is a superuser, prints a 3-option fix when it can't.
- **`setup.sh`** no-arg now defaults to `docker` (was an interactive 1/2 prompt). On re-run it reconciles `PG_USER` and `PG_DATABASE` (previously only `PG_PASSWORD`). Wraps `docker compose up` to catch port-bind failures and suggest the next free port.
- **`server.js`** migration runner fails fast on `role/database/auth/connection` errors with one clear message, instead of logging 40+ `note:` lines before crashing in `recoverOrphanedTasks`.
- **`imagegen/start.sh`** preflights macOS + arm64 + Python ≥3.10 (auto-picks `python3.13/3.12/3.11/3.10` over `/usr/bin/python3` — the 3.9 from Xcode CLT that triggered the slow pip 21.2.4 path) + ≥8 GB disk + huggingface reachability. Skips cleanly (exit 0) on any fail with a one-line reason; `concurrently` no longer sees it as a crash.
- **`speaker/start.sh`** gets the same Python ≥3.10 auto-pick.
- **`README`** prerequisites table and troubleshooting rows updated for the new port defaults; new row for the exact `role "..." does not exist` failure mode.

### Why this matters

A fresh clone now does the right thing end-to-end:

- `git clone && ./setup.sh` → Docker on 5433/6380, no collisions with user's own Postgres on 5432, `.env` written with matching creds, server starts cleanly.
- Already-running brew Postgres on 5432 is detected and ignored (Yabby owns its own ports).
- Imagegen no longer auto-installs torch on Python 3.9 — it picks 3.12+ if available, skips with a clear reason otherwise.

### Behavior summary

| Scenario | Before | After |
|---|---|---|
| Fresh `./setup.sh` on macOS with brew PG on 5432 | Hijacked brew PG → `role "postgres" does not exist` crash | Docker PG on 5433, brew PG untouched, app starts |
| `npm run dev` without setup | Connected to whatever's on 5432, cryptic 40-line crash | One clear error pointing at `./setup.sh docker` |
| First-run on Apple Silicon with only Python 3.9 | Slow pip 21.2.4 install on 3.9, eventually fails | Auto-skip with "Python 3.10+ required" notice |
| First-run on Intel Mac / Linux | `imagegen` errored or hung | Clean skip: "requires Apple Silicon" |
| Port 5433 already in use | `docker compose` failed cryptically | One-line suggested fix with next free port |

## Test plan

- [ ] Fresh clone on macOS with brew Postgres on 5432 → `./setup.sh` succeeds, server boots, `generate_image` either works (Apple Silicon + Python 3.12+) or skips with reason.
- [ ] `npm run dev` on a setup with no Docker and no local Postgres → fails with one clear `[STARTUP] ❌ Cannot run migration` line, not 40 noise lines.
- [ ] `./setup.sh local` against an existing PG with non-default user → `ensure-services.sh` auth probe fails with the 3-option fix message.
- [ ] Re-run `./setup.sh docker` after `./setup.sh local` left a stale `.env` → `PG_USER` / `PG_DATABASE` rewritten correctly.
- [ ] Imagegen preflight: confirm skip path on Intel Mac, Linux, and macOS with only Xcode Python 3.9.
- [ ] Speaker preflight: confirm skip on a system without Python 3.10+.

🤖 Generated with [Claude Code](https://claude.com/claude-code)