### PR TITLE
add Quick Start callouts for OpenAI Realtime and Claude CLI requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,14 @@ If you want a minimal consumer voice app, this is probably too much. If you want
 | Claude CLI | `npm i -g @anthropic-ai/claude-code` |
 | OpenAI API key | Realtime API access |
 
+> ⚠️ **OpenAI Realtime API is required for chat.** OpenYabby's chat path...
+> (full text above)
+
+> ⚠️ **Claude CLI must be on `PATH` for task execution.**...
+> (full text above)
+
+### One-Command Setup
+
 ### One-Command Setup
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -129,13 +129,13 @@ If you want a minimal consumer voice app, this is probably too much. If you want
 | Claude CLI | `npm i -g @anthropic-ai/claude-code` |
 | OpenAI API key | Realtime API access |
 
-> ⚠️ **OpenAI Realtime API is required for chat.** OpenYabby's chat path...
-> (full text above)
+> ⚠️ **OpenAI Realtime API is required for chat.** OpenYabby's chat path (UI and channels like Discord) routes through OpenAI's Realtime API via WebRTC. Without an OpenAI API key that has Realtime API access, the chat will fail — `/session` returns 500 and messages will not reach the agent. Other LLM providers you configure (Anthropic, Groq, Mistral, etc.) only power **internal** LLM calls (reformulation, hallucination detection, channel handlers) — they do not substitute for OpenAI on the chat path. This is the part most people miss when they see the multi-provider setup and assume any of them can drive the conversation.
 
-> ⚠️ **Claude CLI must be on `PATH` for task execution.**...
-> (full text above)
-
-### One-Command Setup
+> ⚠️ **Claude CLI must be on `PATH` for task execution.** If the `claude` binary isn't installed or isn't reachable on your `PATH`, task creation will fail with:
+> - `Error: Process exited avec code -4058` on Windows (Windows's mapping for `ENOENT` in `child_process.spawn`)
+> - `Error: spawn claude ENOENT` or plain `ENOENT` on macOS / Linux
+>
+> Install with `npm i -g @anthropic-ai/claude-code` and verify with `claude --version` before running `npm start`. If you have it installed at a custom path, set `CLAUDE_CMD=/full/path/to/claude` in `.env`.
 
 ### One-Command Setup
 


### PR DESCRIPTION
Closes #14 (docs portion)

## What

Adds two prominent callouts in the Quick Start section, immediately after the Prerequisites table, covering the two most common setup blockers for new contributors:

1. **OpenAI Realtime API requirement** — the chat path routes through Realtime/WebRTC and won't work with any other provider
2. **Claude CLI on `PATH`** — required for task execution, with both Windows (`-4058`) and Unix (`ENOENT`) error signatures spelled out

Per the discussion on #14, the Troubleshooting row for Claude CLI is intentionally kept — it serves readers who already hit the error and are searching for it, which is a different audience from the pre-install scanners.

## Why

These two requirements are listed in the Prerequisites table, but the table format is easy to scan past. New contributors hit `/session` 500 errors and `Error: Process exited avec code -4058` and don't immediately connect them back to the OpenAI / Claude CLI requirements. The callouts spell out the failure modes explicitly so the exact error string is googleable directly into the README.

## Precision details (per @Idov's review on #14)

**OpenAI callout** spells out that Anthropic / Groq / Mistral only drive *internal* LLM calls (reformulation, hallucination detection, channel handlers) — they cannot substitute for OpenAI on the chat path. This is the most common misunderstanding when readers see the multi-provider setup and assume any LLM can drive the conversation.

**Claude CLI callout** documents both error signatures:
- Windows: `Error: Process exited avec code -4058` (Windows's `ENOENT` mapping in `child_process.spawn`)
- macOS / Linux: `Error: spawn claude ENOENT` or plain `ENOENT`

Windows users see their exact code, Unix users recognize the standard message.

## Scope

This PR covers only the documentation portion of #14. The runtime validation pieces (key format check, `CLAUDE_CMD` PATH check at startup, Discord WARN on failed channel processing) are intentionally split into a separate issue / PR for cleaner review — those are behavior changes, this is just README.